### PR TITLE
Add `argv` function, shift comments from ml to mli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 *.cmx
 *.cmxs
 *.cmxa
+_build

--- a/lib/bootvar.mli
+++ b/lib/bootvar.mli
@@ -18,9 +18,16 @@
 type t
 
 val create : unit -> [`Ok of t | `Error of string] Lwt.t
+(** Read boot parameter line. Expected format is ["key1=val1 key2=val2 ..."] *)
 
 val get : t -> string -> string option
-
-val get_exn : t -> string -> string
+(** Get boot parameter. Returns [None] if the parameter is not found. *)
 
 exception Parameter_not_found of string
+
+val get_exn : t -> string -> string
+(** Get boot parameter. Raises [Parameter_not_found] if the parameter is not
+    found. *)
+
+val argv : t -> string array
+(** [argv t] is an [argv]-like array corresponding to [t]. *)


### PR DESCRIPTION
I am not able to test on Xen at the moment, so it would be great if someone could test the `argv` function before merging.

In any case, it seems that this code would be better off being integrated to `mirage-platform`, in particular as an implementation of `OS.Env.argv`:

https://github.com/mirage/mirage-platform/blob/master/xen/lib/env.mli
