### PR TITLE
Add a function to extract the parameter list.

### DIFF
--- a/lib/bootvar.ml
+++ b/lib/bootvar.ml
@@ -57,10 +57,10 @@ let get_exn t parameter =
     Not_found -> raise (Parameter_not_found parameter)
 
 (* Get boot parameter. Returns None if the parameter is not found. *)
-let get t parameter = 
-  try 
-    Some (get_exn t parameter) 
-  with 
-    Parameter_not_found x -> None
+let get t parameter =
+  try
+    Some (List.assoc parameter t.parameters)
+  with
+    Not_found -> None
 
 let parameters x = x.parameters

--- a/lib/bootvar.ml
+++ b/lib/bootvar.ml
@@ -62,3 +62,5 @@ let get t parameter =
     Some (get_exn t parameter) 
   with 
     Parameter_not_found x -> None
+
+let parameters x = x.parameters

--- a/lib/bootvar.ml
+++ b/lib/bootvar.ml
@@ -31,7 +31,6 @@ let get_cmd_line () =
   OS.Xs.(immediate client (fun x -> read x (vm^"/image/cmdline")))
   (*let cmd_line = OS.Start_info.((get ()).cmd_line) in -- currently only works on x86 *)
 
-(* read boot parameter line and store in assoc list - expected format is "key1=val1 key2=val2" *)
 let create () = 
   get_cmd_line () >>= fun cmd_line ->
   let entries = Re_str.(split (regexp_string " ") cmd_line) in
@@ -49,14 +48,12 @@ let create () =
   in
   return t
 
-(* Get boot parameter. Raises Not_found if the parameter is not found. *)
 let get_exn t parameter = 
   try
     List.assoc parameter t.parameters
   with
     Not_found -> raise (Parameter_not_found parameter)
 
-(* Get boot parameter. Returns None if the parameter is not found. *)
 let get t parameter =
   try
     Some (List.assoc parameter t.parameters)

--- a/lib/bootvar.mli
+++ b/lib/bootvar.mli
@@ -24,3 +24,5 @@ val get : t -> string -> string option
 val get_exn : t -> string -> string
 
 exception Parameter_not_found of string
+
+val parameters : t -> (string * string) list

--- a/lib/bootvar.mli
+++ b/lib/bootvar.mli
@@ -17,12 +17,17 @@
 
 type t
 
+(** Read boot parameter line and store in assoc list.
+    Expected format is ["key1=val1 key2=val2"]. *)
 val create : unit -> [`Ok of t | `Error of string] Lwt.t
 
+(** Get boot parameter. Returns [None] if the parameter is not found. *)
 val get : t -> string -> string option
 
+(** Get boot parameter. Raises [Parameter_not_found s] if the parameter is not found. *)
 val get_exn : t -> string -> string
 
 exception Parameter_not_found of string
 
+(** Returns the assoc list of key and values. *)
 val parameters : t -> (string * string) list


### PR DESCRIPTION
I was going to add iter and fold, and realize it was just better to export the list.
The internal representation is not exposed, so you still have the liberty to change it.

I also improved a bit the documentation and removed a layer of exception handler.

NB: The xen backend doesn't work for me at the moment, so It's basically untested. No travis on this repository. :(
