### PR TITLE
For malformed vars, include the string in error

### DIFF
--- a/_tags
+++ b/_tags
@@ -21,3 +21,4 @@ true: annot, bin_annot
 <lib/*.ml{,i,y}>: pkg_re
 <lib/*.ml{,i,y}>: pkg_re.str
 # OASIS_STOP
+true: warn(A-44), strict_sequence

--- a/lib/bootvar.ml
+++ b/lib/bootvar.ml
@@ -15,7 +15,6 @@
  *
  *)
 open Lwt
-open Re
 
 type t = { cmd_line : string;
            parameters : (string * string) list }

--- a/lib/bootvar.ml
+++ b/lib/bootvar.ml
@@ -37,7 +37,8 @@ let create () =
     List.map (fun x ->
         match Re_str.(split (regexp_string "=") x) with 
         | [a;b] -> (a,b)
-        | _ -> raise (Failure "Malformed boot parameters")) entries
+        | _ -> raise (Failure (Printf.sprintf "Malformed boot parameter %S" x))
+      ) entries
   in
   let t = 
     try 


### PR DESCRIPTION
For malformed vars, include the string in error.

(also, enable warnings and remove an unused import it found)
