### PR TITLE
Allow users to pass a filter function to `argv`.

### DIFF
--- a/lib/bootvar.ml
+++ b/lib/bootvar.ml
@@ -69,7 +69,8 @@ let get t parameter =
 
 let parameters x = x.parameters
 
-let to_argv x =
+let to_argv ~filter x =
+  let x = List.filter filter x in
   let argv = Array.make (1 + List.length x) "" in
   let f i (k,v) =
     let dash = if String.length k = 1 then "-" else "--" in
@@ -78,5 +79,5 @@ let to_argv x =
   List.iteri f x ;
   argv
 
-let argv () =
-  create () >>= fun t -> return (to_argv @@ parameters t)
+let argv ?(filter=(fun _ -> true)) () =
+  create () >>= fun t -> return (to_argv ~filter @@ parameters t)

--- a/lib/bootvar.mli
+++ b/lib/bootvar.mli
@@ -33,4 +33,4 @@ exception Parameter_not_found of string
 val parameters : t -> (string * string) list
 
 (** Return an argv-like structure. *)
-val argv : unit -> string array Lwt.t
+val argv : ?filter:((string * string) -> bool) -> unit -> string array Lwt.t


### PR DESCRIPTION
It's sometimes desirable to explicitly ignore some arguments that might
be supplied, but which the implementation doesn't care about.  Allow
users to provide a function with which to filter key-value pairs parsed
by `to_argv` after they've been parsed, but before they're put in order.
