### PR TITLE
refer to mirage module types modules by new name

### DIFF
--- a/examples/unikernel.ml
+++ b/examples/unikernel.ml
@@ -26,7 +26,7 @@
 *)
 open Lwt
 
-module Main (C: V1_LWT.CONSOLE) = struct
+module Main (C: Mirage_types_lwt.CONSOLE) = struct
 
   let start c  = 
     OS.Time.sleep 2.0 (* sleep long enough to see output in console *)


### PR DESCRIPTION
V1 is now Mirage_types, and V1_LWT is now Mirage_types_lwt, as of MirageOS version 3.0.0.