### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/mirage-bootvar-xen.opam
+++ b/mirage-bootvar-xen.opam
@@ -20,7 +20,7 @@ build: [
 ]
 
 depends: [
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
   "mirage-xen" { >= "4.0.0"}
   "lwt" {>="2.4.3"}
   "astring"


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.