### PR TITLE
Update to new Xen core platform stack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,6 @@ env:
   - PACKAGE="mirage-bootvar-xen"
   - DISTRO=alpine
   matrix:
-  - OCAML_VERSION=4.06
-  - OCAML_VERSION=4.07
+  - OCAML_VERSION=4.10
+  - OCAML_VERSION=4.09
   - OCAML_VERSION=4.08

--- a/lib/bootvar.ml
+++ b/lib/bootvar.ml
@@ -14,60 +14,10 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
  *)
-open Lwt
-
-type t = { cmd_line : string;
-           parameters : (string * string) list }
-
-exception Parameter_not_found of string
-
 external get_cmd_line : unit -> string = "mirage_xen_get_cmdline"
 
-let create () =
-  let cmd_line_raw = get_cmd_line () in
-  (* Strip leading whitespace *)
-  let filter_map fn l =
-    List.fold_left (fun acc x ->
-        match fn x with Some y -> y::acc | None -> acc) [] l
-  in
-  let entries = Parse_argv.parse cmd_line_raw in
-  match entries with
-  | Error s -> fail_with s
-  | Ok l ->
-    let parameters =
-      filter_map (fun x ->
-        match Astring.String.cut ~sep:"=" x with
-        | Some (a,b) ->
-          Some (a,b)
-        | _ ->
-          Printf.printf "Ignoring malformed parameter: %s\n" x; None
-      ) l
-    in
-    Lwt.return { cmd_line=cmd_line_raw ; parameters}
-
-let get_exn t parameter =
-  try
-    List.assoc parameter t.parameters
-  with
-    Not_found -> raise (Parameter_not_found parameter)
-
-let get t parameter =
-  try
-    Some (List.assoc parameter t.parameters)
-  with
-    Not_found -> None
-
-let parameters x = x.parameters
-
-let to_argv ~filter x =
-  let x = List.filter filter x in
-  let argv = Array.make (1 + List.length x) "" in
-  let f i (k,v) =
-    let dash = if String.length k = 1 then "-" else "--" in
-    argv.(i + 1) <- Printf.sprintf "%s%s=%s" dash k v
-  in
-  List.iteri f x ;
-  argv
-
-let argv ?(filter=(fun _ -> true)) () =
-  create () >>= fun t -> return (to_argv ~filter @@ parameters t)
+let argv () =
+  let cmd_line = get_cmd_line () in
+  match Parse_argv.parse cmd_line with
+  | Ok l -> Lwt.return (Array.of_list ("mirage" :: l))
+  | Error s -> Lwt.fail_with s

--- a/lib/bootvar.ml
+++ b/lib/bootvar.ml
@@ -21,20 +21,10 @@ type t = { cmd_line : string;
 
 exception Parameter_not_found of string
 
-let get_cmd_line () =
-  (* Originally based on mirage-skeleton/xen/static_website+ip code for reading
-   * boot parameters, but we now read from xenstore for better ARM
-   * compatibility.  *)
-  OS.Xs.make () >>= fun client ->
-  Lwt.catch (fun () ->
-    OS.Xs.(immediate client (fun x -> read x "vm")) >>= fun vm ->
-    OS.Xs.(immediate client (fun x -> read x (vm^"/image/cmdline"))))
-    (fun _ ->
-       let cmdline = (OS.Start_info.get ()).OS.Start_info.cmd_line in
-       Lwt.return cmdline)
+external get_cmd_line : unit -> string = "mirage_xen_get_cmdline"
 
 let create () =
-  get_cmd_line () >>= fun cmd_line_raw ->
+  let cmd_line_raw = get_cmd_line () in
   (* Strip leading whitespace *)
   let filter_map fn l =
     List.fold_left (fun acc x ->

--- a/lib/bootvar.mli
+++ b/lib/bootvar.mli
@@ -15,22 +15,5 @@
  *
  *)
 
-type t
-
-(** Read boot parameter line and store in assoc list.
-    Expected format is ["key1=val1 key2=val2"]. *)
-val create : unit -> t Lwt.t
-
-(** Get boot parameter. Returns [None] if the parameter is not found. *)
-val get : t -> string -> string option
-
-(** Get boot parameter. Raises [Parameter_not_found s] if the parameter is not found. *)
-val get_exn : t -> string -> string
-
-exception Parameter_not_found of string
-
-(** Returns the assoc list of key and values. *)
-val parameters : t -> (string * string) list
-
 (** Return an argv-like structure. *)
-val argv : ?filter:((string * string) -> bool) -> unit -> string array Lwt.t
+val argv : unit -> string array Lwt.t

--- a/mirage-bootvar-xen.opam
+++ b/mirage-bootvar-xen.opam
@@ -21,7 +21,7 @@ build: [
 
 depends: [
   "dune" {>= "1.0"}
-  "mirage-xen" {>= "5.0.0"}
+  "mirage-xen" {>= "6.0.0"}
   "lwt" {>="2.4.3"}
   "astring"
   "parse-argv"

--- a/mirage-bootvar-xen.opam
+++ b/mirage-bootvar-xen.opam
@@ -25,5 +25,5 @@ depends: [
   "lwt" {>="2.4.3"}
   "astring"
   "parse-argv"
-  "ocaml" { >= "4.06.0" }
+  "ocaml" { >= "4.08.0" }
 ]


### PR DESCRIPTION
Update mirage-bootvar-xen to the interface changes in the new Xen core
platform stack.

Part of mirage/mirage#1159, depends on mirage/mirage-xen#23.